### PR TITLE
refactor validator generators

### DIFF
--- a/RhetosPackages/Source/Angular2ModelGenerator/Angular2ModelGenerator.csproj
+++ b/RhetosPackages/Source/Angular2ModelGenerator/Angular2ModelGenerator.csproj
@@ -87,7 +87,9 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="AdditionCodes.cs" />
+    <Compile Include="Filters\ComposableFilterByCodeGenerator.cs" />
+    <Compile Include="Filters\FilterByCodeGenerator.cs" />
+    <Compile Include="Generators\AdditionCodes.cs" />
     <Compile Include="Angular2ModelGenerator.cs" />
     <Compile Include="Angular2ModelGenratorModuleConfiguration.cs" />
     <Compile Include="Contants\CsTagNames.cs" />
@@ -96,13 +98,18 @@
     <Compile Include="Contants\UrlPaths.cs" />
     <Compile Include="CsTagsManager.cs" />
     <Compile Include="Enums\MenuItemType.cs" />
-    <Compile Include="Filters\ComposableFilterByCodeGenerator.cs" />
-    <Compile Include="Filters\FilterByCodeGenerator.cs" />
     <Compile Include="Generators\Entities\Base\BaseEntityGenerator.cs" />
     <Compile Include="Generators\Entities\ComputedStructureGenerator.cs" />
     <Compile Include="Generators\Entities\DataStructureGenerator.cs" />
     <Compile Include="Generators\Entities\Interfaces\IEntityGenerator.cs" />
     <Compile Include="Generators\Interfaces\IAngular2ModelGeneratorPlugin.cs" />
+    <Compile Include="Generators\Validators\Base\BaseValidatorGenerator.cs" />
+    <Compile Include="Generators\Validators\DecimalValidatorGenerator.cs" />
+    <Compile Include="Generators\Validators\Interfaces\IValidatorGenerator.cs" />
+    <Compile Include="Generators\Validators\MaxLengthValidatorGenerator.cs" />
+    <Compile Include="Generators\Validators\MinLengthValidatorGenerator.cs" />
+    <Compile Include="Generators\Validators\RegularExpressionValidatorGenerator.cs" />
+    <Compile Include="Generators\Validators\RequiredValidatorGenerator.cs" />
     <Compile Include="Helpers\StringHelper.cs" />
     <Compile Include="Html\HomePageLink.cs" />
     <Compile Include="Models\AppEntityProviders.cs" />
@@ -115,13 +122,8 @@
     <Compile Include="Property\InvalidPropertytCodeGenerator.cs" />
     <Compile Include="Property\PropertyCodeGeneratorHelper.cs" />
     <Compile Include="Property\ReferencePropertyCodeGenerator.cs" />
-    <Compile Include="Property\DecimalPropertyCodeGenerator.cs" />
     <Compile Include="Repository\ComposableFilterRepository.cs" />
-    <Compile Include="SimpleBusinessLogic\MaxLengthTagCodeGenerator.cs" />
-    <Compile Include="SimpleBusinessLogic\MinLengthTagCodeGenerator.cs" />
-    <Compile Include="SimpleBusinessLogic\RegExTagCodeGenerator.cs" />
     <Compile Include="SimpleBusinessLogic\RowPermissionsCodeGenerator.cs" />
-    <Compile Include="SimpleBusinessLogic\RequiredTagCodeGenerator.cs" />
     <Compile Include="Templates\EntityTemplates.cs" />
     <Compile Include="Templates\FilterTemplates.cs" />
     <Compile Include="Templates\InitialTemplates.cs" />

--- a/RhetosPackages/Source/Angular2ModelGenerator/Generators/AdditionCodes.cs
+++ b/RhetosPackages/Source/Angular2ModelGenerator/Generators/AdditionCodes.cs
@@ -1,7 +1,7 @@
 ﻿using Angular2ModelGenerator.Models;
 using System;
 
-namespace Angular2ModelGenerator
+namespace Angular2ModelGenerator.Generators
 {
     public class AdditionCodes
     {

--- a/RhetosPackages/Source/Angular2ModelGenerator/Generators/Validators/Base/BaseValidatorGenerator.cs
+++ b/RhetosPackages/Source/Angular2ModelGenerator/Generators/Validators/Base/BaseValidatorGenerator.cs
@@ -1,0 +1,23 @@
+﻿using Angular2ModelGenerator.Constants;
+using Angular2ModelGenerator.Generators.Validators.Interfaces;
+using Rhetos.Compiler;
+using Rhetos.Dsl;
+using Rhetos.Dsl.DefaultConcepts;
+
+namespace Angular2ModelGenerator.Generators.Validators.Base
+{
+    public abstract class BaseValidatorGenerator<T> : IValidatorGenerator where T : IConceptInfo
+    {
+        protected abstract string GenerateCode(T info);
+
+        protected abstract PropertyInfo GetConceptInfo(T info);
+
+        public virtual void GenerateCode(IConceptInfo conceptInfo, ICodeBuilder codeBuilder)
+        {
+            if (conceptInfo is T info)
+            {
+                codeBuilder.InsertCode(GenerateCode(info), CsTagsManager.Instance.Get<PropertyInfo>(CsTagNames.Return), GetConceptInfo(info));
+            }
+        }
+    }
+}

--- a/RhetosPackages/Source/Angular2ModelGenerator/Generators/Validators/DecimalValidatorGenerator.cs
+++ b/RhetosPackages/Source/Angular2ModelGenerator/Generators/Validators/DecimalValidatorGenerator.cs
@@ -25,7 +25,7 @@ using Rhetos.Dsl.DefaultConcepts;
 using Rhetos.Extensibility;
 using System.ComponentModel.Composition;
 
-namespace Angular2ModelGenerator.Plugins.Validators
+namespace Angular2ModelGenerator.Generators.Validators
 {
     [Export(typeof(IAngular2ModelGeneratorPlugin))]
     [ExportMetadata(MefProvider.Implements, typeof(DecimalPropertyInfo))]

--- a/RhetosPackages/Source/Angular2ModelGenerator/Generators/Validators/DecimalValidatorGenerator.cs
+++ b/RhetosPackages/Source/Angular2ModelGenerator/Generators/Validators/DecimalValidatorGenerator.cs
@@ -17,37 +17,28 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-using Rhetos.Compiler;
-using Rhetos.Dsl;
+using Angular2ModelGenerator.Constants;
+using Angular2ModelGenerator.Generators.Interfaces;
+using Angular2ModelGenerator.Generators.Validators.Base;
+using Angular2ModelGenerator.Templates;
 using Rhetos.Dsl.DefaultConcepts;
 using Rhetos.Extensibility;
 using System.ComponentModel.Composition;
-using Angular2ModelGenerator.Generators.Interfaces;
 
-namespace Angular2ModelGenerator.Property
+namespace Angular2ModelGenerator.Plugins.Validators
 {
     [Export(typeof(IAngular2ModelGeneratorPlugin))]
     [ExportMetadata(MefProvider.Implements, typeof(DecimalPropertyInfo))]
-    public class DecimalPropertyCodeGenerator : IAngular2ModelGeneratorPlugin
+    public class DecimalValidatorGenerator : BaseValidatorGenerator<DecimalPropertyInfo>
     {
-        public void GenerateCode(IConceptInfo conceptInfo, ICodeBuilder codeBuilder)
+        protected override string GenerateCode(DecimalPropertyInfo info)
         {
-            var info = (DecimalPropertyInfo)conceptInfo;
-
-            codeBuilder.InsertCode(ValidatorsCodeSnippet(info), PropertyCodeGeneratorHelper.ReturnTag, info);
+            return ValidatorTemplates.Decimal(RegularExpressions.Decimal.Replace("\\", "\\\\"), Messages.Errors.Decimal);
         }
 
-        private static string ValidatorsCodeSnippet(DecimalPropertyInfo info)
+        protected override PropertyInfo GetConceptInfo(DecimalPropertyInfo info)
         {
-            string RegularExpression = "^-?[0-9]+(\\.[0-9]+)?$";
-            string ErrorMessage = "Example: 100.0, 100.10 ";
-            string result = string.Format(
-                @"{{Validator: RegexValidatorFactory(""{0}""), ErrorCode: 'notMatchingRegex', ErrorMessage: ""{1}"" }},
-                ",
-                RegularExpression.Replace("\\","\\\\"),
-                ErrorMessage
-                );
-            return result;
+            return info;
         }
     }
 }

--- a/RhetosPackages/Source/Angular2ModelGenerator/Generators/Validators/Interfaces/IValidatorGenerator.cs
+++ b/RhetosPackages/Source/Angular2ModelGenerator/Generators/Validators/Interfaces/IValidatorGenerator.cs
@@ -1,0 +1,8 @@
+﻿using Angular2ModelGenerator.Generators.Interfaces;
+
+namespace Angular2ModelGenerator.Generators.Validators.Interfaces
+{
+    public interface IValidatorGenerator : IAngular2ModelGeneratorPlugin
+    {
+    }
+}

--- a/RhetosPackages/Source/Angular2ModelGenerator/Generators/Validators/MaxLengthValidatorGenerator.cs
+++ b/RhetosPackages/Source/Angular2ModelGenerator/Generators/Validators/MaxLengthValidatorGenerator.cs
@@ -24,7 +24,7 @@ using Rhetos.Dsl.DefaultConcepts;
 using Rhetos.Extensibility;
 using System.ComponentModel.Composition;
 
-namespace Angular2ModelGenerator.Plugins.Validation
+namespace Angular2ModelGenerator.Generators.Validators
 {
     [Export(typeof(IAngular2ModelGeneratorPlugin))]
     [ExportMetadata(MefProvider.Implements, typeof(MaxLengthInfo))]

--- a/RhetosPackages/Source/Angular2ModelGenerator/Generators/Validators/MaxLengthValidatorGenerator.cs
+++ b/RhetosPackages/Source/Angular2ModelGenerator/Generators/Validators/MaxLengthValidatorGenerator.cs
@@ -17,33 +17,27 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-using Rhetos.Compiler;
-using Rhetos.Dsl;
+using Angular2ModelGenerator.Generators.Interfaces;
+using Angular2ModelGenerator.Generators.Validators.Base;
+using Angular2ModelGenerator.Templates;
 using Rhetos.Dsl.DefaultConcepts;
 using Rhetos.Extensibility;
 using System.ComponentModel.Composition;
-using Angular2ModelGenerator.Property;
-using Angular2ModelGenerator.Generators.Interfaces;
 
-namespace Angular2ModelGenerator.SimpleBusinessLogic
+namespace Angular2ModelGenerator.Plugins.Validation
 {
     [Export(typeof(IAngular2ModelGeneratorPlugin))]
-    [ExportMetadata(MefProvider.Implements, typeof(RequiredPropertyInfo))]
-    public class RequiredTagCodeGenerator : IAngular2ModelGeneratorPlugin
+    [ExportMetadata(MefProvider.Implements, typeof(MaxLengthInfo))]
+    public class MaxLengthValidatorGenerator : BaseValidatorGenerator<MaxLengthInfo>
     {
-        public void GenerateCode(IConceptInfo conceptInfo, ICodeBuilder codeBuilder)
+        protected override string GenerateCode(MaxLengthInfo info)
         {
-            var info = (RequiredPropertyInfo)conceptInfo;
-            codeBuilder.InsertCode(ValidatorsCodeSnippet(info),PropertyCodeGeneratorHelper.ReturnTag,info.Property);
+            return ValidatorTemplates.MaxLength(info.Property.Name, info.Length);
         }
 
-        private static string ValidatorsCodeSnippet(RequiredPropertyInfo info)
+        protected override PropertyInfo GetConceptInfo(MaxLengthInfo info)
         {
-            string result = string.Format(
-                @"{{Validator :Validators.required, ErrorCode: 'required', ErrorMessage: ""{0} is required"" }},
-                ",
-                info.Property.Name);
-            return result;
+            return info.Property;
         }
     }
 }

--- a/RhetosPackages/Source/Angular2ModelGenerator/Generators/Validators/MinLengthValidatorGenerator.cs
+++ b/RhetosPackages/Source/Angular2ModelGenerator/Generators/Validators/MinLengthValidatorGenerator.cs
@@ -17,35 +17,27 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-using Rhetos.Compiler;
-using Rhetos.Dsl;
+using Angular2ModelGenerator.Generators.Interfaces;
+using Angular2ModelGenerator.Generators.Validators.Base;
+using Angular2ModelGenerator.Templates;
 using Rhetos.Dsl.DefaultConcepts;
 using Rhetos.Extensibility;
 using System.ComponentModel.Composition;
-using Angular2ModelGenerator.Property;
-using Angular2ModelGenerator.Generators.Interfaces;
 
-namespace Angular2ModelGenerator.SimpleBusinessLogic
+namespace Angular2ModelGenerator.Plugins.Validation
 {
     [Export(typeof(IAngular2ModelGeneratorPlugin))]
-    [ExportMetadata(MefProvider.Implements, typeof(MaxLengthInfo))]
-    public class MaxLengthTagCodeGenerator : IAngular2ModelGeneratorPlugin
+    [ExportMetadata(MefProvider.Implements, typeof(MinLengthInfo))]
+    public class MinLengthValidatorGenerator : BaseValidatorGenerator<MinLengthInfo>
     {
-        public void GenerateCode(IConceptInfo conceptInfo, ICodeBuilder codeBuilder)
+        protected override string GenerateCode(MinLengthInfo info)
         {
-            var info = (MaxLengthInfo)conceptInfo;
-
-            codeBuilder.InsertCode(ValidatorsCodeSnippet(info), PropertyCodeGeneratorHelper.ReturnTag, info.Property);
+            return ValidatorTemplates.MinLength(info.Property.Name, info.Length);
         }
 
-        private static string ValidatorsCodeSnippet(MaxLengthInfo info)
+        protected override PropertyInfo GetConceptInfo(MinLengthInfo info)
         {
-            string result = string.Format(
-                @"{{Validator :Validators.maxLength({1}), ErrorCode: 'maxlength', ErrorMessage: ""{0} has maximum length of {1} characters"" }},
-                ",
-                info.Property.Name,
-                info.Length);
-            return result;
+            return info.Property;
         }
     }
 }

--- a/RhetosPackages/Source/Angular2ModelGenerator/Generators/Validators/MinLengthValidatorGenerator.cs
+++ b/RhetosPackages/Source/Angular2ModelGenerator/Generators/Validators/MinLengthValidatorGenerator.cs
@@ -24,7 +24,7 @@ using Rhetos.Dsl.DefaultConcepts;
 using Rhetos.Extensibility;
 using System.ComponentModel.Composition;
 
-namespace Angular2ModelGenerator.Plugins.Validation
+namespace Angular2ModelGenerator.Generators.Validators
 {
     [Export(typeof(IAngular2ModelGeneratorPlugin))]
     [ExportMetadata(MefProvider.Implements, typeof(MinLengthInfo))]

--- a/RhetosPackages/Source/Angular2ModelGenerator/Generators/Validators/RegularExpressionValidatorGenerator.cs
+++ b/RhetosPackages/Source/Angular2ModelGenerator/Generators/Validators/RegularExpressionValidatorGenerator.cs
@@ -24,7 +24,7 @@ using Rhetos.Dsl.DefaultConcepts;
 using Rhetos.Extensibility;
 using System.ComponentModel.Composition;
 
-namespace Angular2ModelGenerator.Plugins.Validation
+namespace Angular2ModelGenerator.Generators.Validators
 {
     [Export(typeof(IAngular2ModelGeneratorPlugin))]
     [ExportMetadata(MefProvider.Implements, typeof(RegExMatchInfo))]

--- a/RhetosPackages/Source/Angular2ModelGenerator/Generators/Validators/RegularExpressionValidatorGenerator.cs
+++ b/RhetosPackages/Source/Angular2ModelGenerator/Generators/Validators/RegularExpressionValidatorGenerator.cs
@@ -17,36 +17,27 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-using Rhetos.Compiler;
-using Rhetos.Dsl;
+using Angular2ModelGenerator.Generators.Interfaces;
+using Angular2ModelGenerator.Generators.Validators.Base;
+using Angular2ModelGenerator.Templates;
 using Rhetos.Dsl.DefaultConcepts;
 using Rhetos.Extensibility;
-using Rhetos.Utilities;
 using System.ComponentModel.Composition;
-using Angular2ModelGenerator.Property;
-using Angular2ModelGenerator.Generators.Interfaces;
 
-namespace Angular2ModelGenerator.SimpleBusinessLogic
+namespace Angular2ModelGenerator.Plugins.Validation
 {
     [Export(typeof(IAngular2ModelGeneratorPlugin))]
     [ExportMetadata(MefProvider.Implements, typeof(RegExMatchInfo))]
-    public class RegExTagCodeGenerator : IAngular2ModelGeneratorPlugin
+    public class RegExTagCodeGenerator : BaseValidatorGenerator<RegExMatchInfo>
     {
-        public void GenerateCode(IConceptInfo conceptInfo, ICodeBuilder codeBuilder)
+        protected override string GenerateCode(RegExMatchInfo info)
         {
-            var info = (RegExMatchInfo)conceptInfo;
-            codeBuilder.InsertCode(ValidatorsCodeSnippet(info), PropertyCodeGeneratorHelper.ReturnTag, info.Property);
-            
+            return ValidatorTemplates.Regex(info.RegularExpression.Replace("\\", "\\\\"), info.ErrorMessage);
         }
-        private static string ValidatorsCodeSnippet(RegExMatchInfo info)
+
+        protected override PropertyInfo GetConceptInfo(RegExMatchInfo info)
         {
-            string result = string.Format(
-                @"{{Validator: RegexValidatorFactory(""{1}""), ErrorCode: 'notMatchingRegex', ErrorMessage: ""{2}"" }},
-                ",
-                info.Property.Name,
-                info.RegularExpression.Replace("\\","\\\\"),
-                info.ErrorMessage);
-            return result;
+            return info.Property;
         }
     }
 }

--- a/RhetosPackages/Source/Angular2ModelGenerator/Generators/Validators/RequiredValidatorGenerator.cs
+++ b/RhetosPackages/Source/Angular2ModelGenerator/Generators/Validators/RequiredValidatorGenerator.cs
@@ -24,7 +24,7 @@ using Rhetos.Dsl.DefaultConcepts;
 using Rhetos.Extensibility;
 using System.ComponentModel.Composition;
 
-namespace Angular2ModelGenerator.Plugins.Validation
+namespace Angular2ModelGenerator.Generators.Validators
 {
     [Export(typeof(IAngular2ModelGeneratorPlugin))]
     [ExportMetadata(MefProvider.Implements, typeof(RequiredPropertyInfo))]

--- a/RhetosPackages/Source/Angular2ModelGenerator/Generators/Validators/RequiredValidatorGenerator.cs
+++ b/RhetosPackages/Source/Angular2ModelGenerator/Generators/Validators/RequiredValidatorGenerator.cs
@@ -17,34 +17,27 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-using Rhetos.Compiler;
-using Rhetos.Dsl;
+using Angular2ModelGenerator.Generators.Interfaces;
+using Angular2ModelGenerator.Generators.Validators.Base;
+using Angular2ModelGenerator.Templates;
 using Rhetos.Dsl.DefaultConcepts;
 using Rhetos.Extensibility;
 using System.ComponentModel.Composition;
-using Angular2ModelGenerator.Property;
-using Angular2ModelGenerator.Generators.Interfaces;
 
-namespace Angular2ModelGenerator.SimpleBusinessLogic
+namespace Angular2ModelGenerator.Plugins.Validation
 {
     [Export(typeof(IAngular2ModelGeneratorPlugin))]
-    [ExportMetadata(MefProvider.Implements, typeof(MinLengthInfo))]
-    public class MinLengthTagCodeGenerator : IAngular2ModelGeneratorPlugin
+    [ExportMetadata(MefProvider.Implements, typeof(RequiredPropertyInfo))]
+    public class RequiredTagCodeGenerator : BaseValidatorGenerator<RequiredPropertyInfo>
     {
-        public void GenerateCode(IConceptInfo conceptInfo, ICodeBuilder codeBuilder)
+        protected override string GenerateCode(RequiredPropertyInfo info)
         {
-            var info = (MinLengthInfo)conceptInfo;
-            codeBuilder.InsertCode(ValidatorsCodeSnippet(info), PropertyCodeGeneratorHelper.ReturnTag, info.Property);
-
+            return ValidatorTemplates.Required(info.Property.Name);
         }
-        private static string ValidatorsCodeSnippet(MinLengthInfo info)
+
+        protected override PropertyInfo GetConceptInfo(RequiredPropertyInfo info)
         {
-            string result = string.Format(
-                @"{{Validator :Validators.minLength({1}), ErrorCode: 'minlength', ErrorMessage: ""{0} has minimum length of {1} characters"" }},
-                ",
-                info.Property.Name,
-                info.Length);
-            return result;
+            return info.Property;
         }
     }
 }


### PR DESCRIPTION
1. Move AdditionCodes to folder '/Generators'
2. Refactor validator generators.
   - Rename class 'DecimalPropertyCodeGenerator' to 'DecimalValidatorGenerator' as it generates a validator for decimal
   - Create a base class named 'BaseValidatorGenerator' in folder '/Generators/Validators/Base'
   - Move the following classes to folder '/Generators/Validators
       + Property\DecimalPropertyCodeGenerator.cs
       + SimpleBusinessLogic\MaxLengthTagCodeGenerator.cs
       + SimpleBusinessLogic\MinLengthTagCodeGenerator.cs
       + SimpleBusinessLogic\RegExTagCodeGenerator.cs
       + SimpleBusinessLogic\RowPermissionsCodeGenerator.cs
       + SimpleBusinessLogic\RequiredTagCodeGenerator.cs
