### PR TITLE
Lazy catching errors after all commands

### DIFF
--- a/Init.ps1
+++ b/Init.ps1
@@ -15,13 +15,16 @@ Process {
 
         Write-Verbose "Download and install Rhetos server."
         Install-RhetosServer
-
+		if (!$?) { throw }
+		
         Write-Verbose "Initialize default configurations for the testing Rhetos server."
         Initialize-RhetosServer $SQLServer $DatabaseName
-
+		if (!$?) { throw }
+		
         Write-Verbose "Prepare directories required by the projects."
         New-PluginBinaryDirectories
-
+		if (!$?) { throw }
+		
         Pop-Location
     }
     catch {

--- a/Publish.ps1
+++ b/Publish.ps1
@@ -14,12 +14,15 @@ Process {
 
         Write-Verbose "Build plugins"
         Build-Plugins -buildConfiguration "Release"
+		if (!$?) { throw }
 
         Write-Verbose "Build AdminGui frontend"
         Build-Frontend
+		if (!$?) { throw }
 
         Write-Verbose "Create new nuget packages"
         New-NugetPackages -buildVersion $BuildVersion -prereleaseVersion "" -isPublish $true
+		if (!$?) { throw }
 
         Pop-Location
     }

--- a/Run.ps1
+++ b/Run.ps1
@@ -14,21 +14,27 @@ Process {
 
         Write-Verbose "Build the plugins."
         Build-Plugins
+        if (!$?) { throw }
 
         Write-Verbose "Build AdminGui frontend"
         Build-Frontend
+        if (!$?) { throw }
 
         Write-Verbose "Create new nuget packages"
         New-NugetPackages
+        if (!$?) { throw }
 
         Write-Verbose "Update local testing Rhetos server with latest changes of local branch."
         Update-RhetosServer -ErrorAction Stop
+        if (!$?) { throw }
         
         Write-Verbose "Register testing Rhetos server as an IIS Express website."
         Register-IISExpressSite $DatabaseName $Port
+        if (!$?) { throw }
 
         Write-Verbose "Set required admin permissions."
         Set-AdminPermissions $SqlServer $DatabaseName
+        if (!$?) { throw }
 
         if ($SkipIISExpress -eq $false) {
             Write-Verbose "Run the testing IIS Express website."


### PR DESCRIPTION
## Motivation
Right now, there are commands that throws termination errors. There are commands which don't. These can result in negative build success in PR checks and many unwanted behaviour in development use cases.

Commands should throw exceptions internally but for now, and I also think it does not hurt if we double-check.