### PR TITLE
Changes double quotes to single quotes in Typescript templates

### DIFF
--- a/Plugins/AdminGuiPlugin/Angular2ModelGenerator/Contants/TypeScript.cs
+++ b/Plugins/AdminGuiPlugin/Angular2ModelGenerator/Contants/TypeScript.cs
@@ -2,6 +2,8 @@
 {
     public class TypeScript
     {
+        public static readonly string[] SpecialCharacters = new string[] { "'" };
+
         public class Types
         {
             public const string Binary = "binary";

--- a/Plugins/AdminGuiPlugin/Angular2ModelGenerator/Generators/Properties/InvalidPropertyGenerator.cs
+++ b/Plugins/AdminGuiPlugin/Angular2ModelGenerator/Generators/Properties/InvalidPropertyGenerator.cs
@@ -1,8 +1,10 @@
 ﻿using Angular2ModelGenerator.Constants;
 using Angular2ModelGenerator.Generators.Interfaces;
 using Angular2ModelGenerator.Generators.Properties.Base;
+using Angular2ModelGenerator.Helpers;
 using Rhetos.Dsl.DefaultConcepts;
 using Rhetos.Extensibility;
+using System;
 using System.ComponentModel.Composition;
 using System.Text.RegularExpressions;
 
@@ -14,7 +16,11 @@ namespace Angular2ModelGenerator.Generators.Properties
     {
         protected override string GetErrorMessage(InvalidDataInfo info)
         {
-            return Regex.Replace(info.ErrorMessage, RegularExpressions.DetectEscape, m => m.Value.Replace("\"", ""));
+            return Regex.Replace(
+                StringHelper.EscapeSpecialCharacters(info.ErrorMessage, TypeScript.SpecialCharacters),
+                RegularExpressions.DetectEscape,
+                m => m.Value.Replace("\"", "")
+                );
         }
 
         protected override string GetModuleName(InvalidDataInfo info)

--- a/Plugins/AdminGuiPlugin/Angular2ModelGenerator/Generators/Validators/RegularExpressionValidatorGenerator.cs
+++ b/Plugins/AdminGuiPlugin/Angular2ModelGenerator/Generators/Validators/RegularExpressionValidatorGenerator.cs
@@ -17,8 +17,10 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+using Angular2ModelGenerator.Constants;
 using Angular2ModelGenerator.Generators.Interfaces;
 using Angular2ModelGenerator.Generators.Validators.Base;
+using Angular2ModelGenerator.Helpers;
 using Angular2ModelGenerator.Templates;
 using Rhetos.Dsl.DefaultConcepts;
 using Rhetos.Extensibility;
@@ -32,7 +34,10 @@ namespace Angular2ModelGenerator.Generators.Validators
     {
         protected override string GenerateCode(RegExMatchInfo info)
         {
-            return ValidatorTemplates.Regex(info.RegularExpression.Replace("\\", "\\\\"), info.ErrorMessage);
+            return ValidatorTemplates.Regex(
+                StringHelper.EscapeSpecialCharacters(info.RegularExpression, TypeScript.SpecialCharacters),
+                StringHelper.EscapeSpecialCharacters(info.ErrorMessage, TypeScript.SpecialCharacters)
+            );
         }
 
         protected override PropertyInfo GetConceptInfo(RegExMatchInfo info)

--- a/Plugins/AdminGuiPlugin/Angular2ModelGenerator/Helpers/StringHelper.cs
+++ b/Plugins/AdminGuiPlugin/Angular2ModelGenerator/Helpers/StringHelper.cs
@@ -7,7 +7,7 @@ namespace Angular2ModelGenerator.Helpers
     public class StringHelper
     {
         public static string RegexReplace(string input, params KeyValuePair<string, string>[] replacements)
-        {
+        { 
             if (replacements.Length == 0)
                 return input;
 
@@ -25,6 +25,17 @@ namespace Angular2ModelGenerator.Helpers
         public static string Spaces(int number)
         {
             return string.Concat(Enumerable.Repeat(" ", number));
+        }
+
+        public static string EscapeSpecialCharacters(string input, params string[] patterns)
+        {
+            if (patterns.Length == 0)
+                return input;
+
+            if (patterns.Length == 1)
+                return input.Replace(patterns[0], $@"\{patterns[0]}");
+
+            return EscapeSpecialCharacters(input.Replace(patterns[0], $@"\{patterns[0]}"), patterns.Skip(1).ToArray());
         }
     }
 }

--- a/Plugins/AdminGuiPlugin/Angular2ModelGenerator/Templates/EntityTemplates.cs
+++ b/Plugins/AdminGuiPlugin/Angular2ModelGenerator/Templates/EntityTemplates.cs
@@ -20,8 +20,8 @@ export class {className} extends BaseEntity implements BaseEntityWithFilters
 
     getInstance(): IEmptyConstruct {{ return  {className}; }}
     getNewInstance(): IDataStructure {{ return new {className}(); }}
-    getModuleName(): string {{ return ""{module}""; }}
-    getEntityName(): string {{ return ""{name}""; }}
+    getModuleName(): string {{ return '{module}'; }}
+    getEntityName(): string {{ return '{name}'; }}
     {fields}
     {setMethods}
     {getMethods}
@@ -114,15 +114,15 @@ export class AllMenuItemModels{}";
                 return $@"
 @AppMenuItem(
     {{
-        Name: ""{name}"",
-        Link: """",
-        Icon: ""{icon}"",
-        Tooltip: """",
+        Name: '{name}',
+        Link: '',
+        Icon: '{icon}',
+        Tooltip: '',
         Children:
         [
             {items}
         ],
-        ClaimResource: """"
+        ClaimResource: ''
     }})
 ";
             }
@@ -131,16 +131,16 @@ export class AllMenuItemModels{}";
             {
                 return $@"
             {{
-                Name: ""{name}"",
-                Link: """",
-                Icon: ""{icon}"",
-                Tooltip: """",
-                Parent: ""{parent}"",
+                Name: '{name}',
+                Link: '',
+                Icon: '{icon}',
+                Tooltip: '',
+                Parent: '{parent}',
                 Children:
                 [
                     {items}
                 ],
-                ClaimResource: """"
+                ClaimResource: ''
             }},
 ";
             }
@@ -157,13 +157,13 @@ export class AllMenuItemModels{}";
             {
                 return $@"
                     {{
-                        Name: ""{moduleName} {entityName}"",
-                        Link: ""{urlPath}"",
-                        Tooltip: ""{tooltip}"",
-                        Icon: ""{icon}"",
-                        ClaimResource: ""{moduleName}.{entityName}"",
-                        Parent: ""{parent}"",
-                        ClaimRight: ""Read"",
+                        Name: '{moduleName} {entityName}',
+                        Link: '{urlPath}',
+                        Tooltip: '{tooltip}',
+                        Icon: '{icon}',
+                        ClaimResource: '{moduleName}.{entityName}',
+                        Parent: '{parent}',
+                        ClaimRight: 'Read',
                         Children: []
                     }},
 ";

--- a/Plugins/AdminGuiPlugin/Angular2ModelGenerator/Templates/FilterTemplates.cs
+++ b/Plugins/AdminGuiPlugin/Angular2ModelGenerator/Templates/FilterTemplates.cs
@@ -4,7 +4,7 @@
     {
         public static string Composable(string name, string filter, bool isComposable)
         {
-            return $@"{{ name:"" {name} "", filter: ""{filter}"", isComposableFilter: {isComposable.ToString().ToLower()}  }},
+            return $@"{{ name:' {name} ', filter: '{filter}', isComposableFilter: {isComposable.ToString().ToLower()}  }},
             ";
         }
 

--- a/Plugins/AdminGuiPlugin/Angular2ModelGenerator/Templates/PropertyTemplates.cs
+++ b/Plugins/AdminGuiPlugin/Angular2ModelGenerator/Templates/PropertyTemplates.cs
@@ -12,7 +12,7 @@ $@"public {name}{suffix} : {type};
         public static string BrowseFields(string name, string type, string pipe)
         {
             return 
-$@"{{ Name: ""{name}"", Title: ""{name}"", Pipe: ""{pipe}"", DataType: DataTypeEnum.{type}, IsFilterEnabled: true }},
+$@"{{ Name: '{name}', Title: '{name}', Pipe: '{pipe}', DataType: DataTypeEnum.{type}, IsFilterEnabled: true }},
         ";
         }
 
@@ -25,7 +25,7 @@ $@"{{ Name: ""{name}"", Title: ""{name}"", Pipe: ""{pipe}"", DataType: DataTypeE
             string spaces = "")
         {
             return 
-$@"{{ Name: ""{name}{suffix}"", Title: ""{name}{suffix}"", Pipe: ""{pipe}"", DataType: DataTypeEnum.{type}, IsFilterEnabled: true, ReferenceType: ""{referenceType}"" }},
+$@"{{ Name: '{name}{suffix}', Title: '{name}{suffix}', Pipe: '{pipe}', DataType: DataTypeEnum.{type}, IsFilterEnabled: true, ReferenceType: '{referenceType}' }},
         ";
         }
 
@@ -39,21 +39,21 @@ $@"this.{name}{suffix} = modelData.{name}{suffix};
         public static string Invalid(string name, string module)
         {
             return 
-$@"{{ name:"" {name} "", filter: ""{module}.{name}"" }},
+$@"{{ name:' {name} ', filter: '{module}.{name}' }},
             ";
         }
 
         public static string Invalid(string name, string module, string errorMessage)
         {
             return 
-$@"{{ name:"" {name} "", filter: ""{module}.{name}"", message: ""{errorMessage}"" }},
+$@"{{ name:' {name} ', filter: '{module}.{name}', message: '{errorMessage}' }},
             ";
         }
 
         public static string ReturnValues(string name, string suffix, string values)
         {
             return 
-$@"""{name}{suffix}"":[
+$@"'{name}{suffix}':[
                 {values}
             ],
             ";

--- a/Plugins/AdminGuiPlugin/Angular2ModelGenerator/Templates/ValidatorTemplates.cs
+++ b/Plugins/AdminGuiPlugin/Angular2ModelGenerator/Templates/ValidatorTemplates.cs
@@ -4,31 +4,31 @@
     {
         public static string MaxLength(string propertyName, string length)
         {
-            return $@"{{Validator :Validators.maxLength({length}), ErrorCode: 'maxlength', ErrorMessage: ""{propertyName} has maximum length of {length} characters"" }},
+            return $@"{{Validator :Validators.maxLength({length}), ErrorCode: 'maxlength', ErrorMessage: '{propertyName} has maximum length of {length} characters' }},
                 ";
         }
 
         public static string MinLength(string propertyName, string length)
         {
-            return $@"{{Validator :Validators.minLength({length}), ErrorCode: 'minlength', ErrorMessage: ""{propertyName} has minimum length of {length} characters"" }},
+            return $@"{{Validator :Validators.minLength({length}), ErrorCode: 'minlength', ErrorMessage: '{propertyName} has minimum length of {length} characters' }},
                 ";
         }
 
         public static string Regex(string regex, string errorMessage)
         {
-            return $@"{{Validator: RegexValidatorFactory(""{regex}""), ErrorCode: 'notMatchingRegex', ErrorMessage: ""{errorMessage}"" }},
+            return $@"{{Validator: RegexValidatorFactory('{regex}'), ErrorCode: 'notMatchingRegex', ErrorMessage: '{errorMessage}' }},
                 ";
         }
 
         public static string Required(string propertyName)
         {
-            return $@"{{Validator :Validators.required, ErrorCode: 'required', ErrorMessage: ""{propertyName} is required"" }},
+            return $@"{{Validator :Validators.required, ErrorCode: 'required', ErrorMessage: '{propertyName} is required' }},
                 ";
         }
 
         public static string Decimal(string regex, string errorMessage)
         {
-            return $@"{{Validator: RegexValidatorFactory(""{regex}""), ErrorCode: 'notMatchingRegex', ErrorMessage: ""{errorMessage}""}}
+            return $@"{{Validator: RegexValidatorFactory('{regex}'), ErrorCode: 'notMatchingRegex', ErrorMessage: '{errorMessage}'}}
                 ";
         }
     }


### PR DESCRIPTION
In **Rhetos.Angular2.ts**, string often in double quotes, so I change it to single quotes for using double quotes inside string.

This will resolve issue fixes #34 and #33 